### PR TITLE
Make race detector not detect race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.17
 require github.com/hajimehoshi/ebiten/v2 v2.2.7
 
 require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210727001814-0db043d8d5be // indirect
 	github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56 // indirect
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d // indirect
 	golang.org/x/mobile v0.0.0-20210902104108-5d9a33257ab5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210727001814-0db043d8d5be h1:vEIVIuBApEBQTEJt19GfhoU+zFSV+sNTa9E9FdnRYfk=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210727001814-0db043d8d5be/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/hajimehoshi/bitmapfont/v2 v2.1.3/go.mod h1:2BnYrkTQGThpr/CY6LorYtt/zEPNzvE/ND69CRTaHMs=
@@ -14,6 +16,11 @@ github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240/go.mod h1:3P4UH/k22rXyHI
 github.com/jfreymuth/oggvorbis v1.0.3/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
 github.com/jfreymuth/vorbis v1.0.2/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -68,3 +75,6 @@ golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/slippymap/cachedtileprovider_test.go
+++ b/slippymap/cachedtileprovider_test.go
@@ -1,6 +1,7 @@
 package slippymap
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -39,13 +40,8 @@ func TestNewCachedTileProvider(t *testing.T) {
 		t.Errorf("Expected: %s, got: %s", expectedPath, tilePath)
 	}
 
-	// prepare "faulty" OSMTileProvider
-	faultyOSMTileProvider := OSMTileProvider{
-		osm_url_prefix: 4,
-	}
-
 	// get cached tile provider
-	ctp = NewCachedTileProvider(dir, &faultyOSMTileProvider)
+	ctp = NewCachedTileProvider(dir, &FaultyTileProvider{})
 
 	// request a tile
 	tilePath, err = ctp.GetTileAddress(2, 3, 4)
@@ -55,4 +51,10 @@ func TestNewCachedTileProvider(t *testing.T) {
 		t.Errorf("Expected an error, got none")
 	}
 
+}
+
+type FaultyTileProvider struct{}
+
+func (FaultyTileProvider) GetTileAddress(int, int, int) (string, error) {
+	return "", errors.New("oh no an error")
 }

--- a/slippymap/osmtileprovider.go
+++ b/slippymap/osmtileprovider.go
@@ -3,12 +3,13 @@ package slippymap
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 )
 
 // OSMTileProvider generates the URLs to OSM tiles
 type OSMTileProvider struct {
 	// used to round-robin connections to OSM servers, as-per https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers
-	osm_url_prefix int
+	osm_url_prefix int32
 }
 
 var _ TileProvider = &OSMTileProvider{}
@@ -17,16 +18,22 @@ func (op *OSMTileProvider) GetTileAddress(x, y, z int) (tilePath string, err err
 	var url string
 	// returns URL to open street map tile
 	// load balance urls across servers as-per OSM guidelines: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers
-	switch op.osm_url_prefix {
+
+	// we don't really care about atomically incrementing this number, but golang race detection bitches
+	// at us if we let this be subject to race conditions. Performance not super critical so just use
+	// atomic to make the race detector shut up
+	nextCDN := atomic.AddInt32(&op.osm_url_prefix, 1) % 3
+
+	switch nextCDN {
 	case 0:
 		url = fmt.Sprintf("http://a.tile.openstreetmap.org/%d/%d/%d.png", z, x, y)
-		op.osm_url_prefix = 1
+
 	case 1:
 		url = fmt.Sprintf("http://b.tile.openstreetmap.org/%d/%d/%d.png", z, x, y)
-		op.osm_url_prefix = 2
+
 	case 2:
 		url = fmt.Sprintf("http://c.tile.openstreetmap.org/%d/%d/%d.png", z, x, y)
-		op.osm_url_prefix = 0
+
 	default:
 		return "", errors.New("invalid osm_url_prefix")
 	}

--- a/slippymap/osmtileprovider_test.go
+++ b/slippymap/osmtileprovider_test.go
@@ -1,53 +1,36 @@
 package slippymap
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestGetTileAddress(t *testing.T) {
 
-	TileProvider := &OSMTileProvider{}
+	t.Run("GetTileAddress loops through CDNs correctly", func(t *testing.T) {
+		// -1 so that the first increment lands us up on CDN A. Doesn't really matter where it starts though
+		TileProvider := &OSMTileProvider{osm_url_prefix: -1}
 
-	// check correct a... url is returned
-	url, err := TileProvider.GetTileAddress(1, 2, 3)
-	if err != nil {
-		t.Error(err)
-	}
-	if url != "http://a.tile.openstreetmap.org/3/1/2.png" {
-		t.Errorf("Expected http://a.tile.openstreetmap.org/3/1/2.png, got: %s", url)
-	}
+		// check correct a... url is returned
+		url, err := TileProvider.GetTileAddress(1, 2, 3)
+		require.NoError(t, err)
+		assert.Equal(t, "http://a.tile.openstreetmap.org/3/1/2.png", url)
 
-	// check correct b... url is returned
-	url, err = TileProvider.GetTileAddress(1, 2, 3)
-	if err != nil {
-		t.Error(err)
-	}
-	if url != "http://b.tile.openstreetmap.org/3/1/2.png" {
-		t.Errorf("Expected http://b.tile.openstreetmap.org/3/1/2.png, got: %s", url)
-	}
+		// check correct b... url is returned
+		url, err = TileProvider.GetTileAddress(1, 2, 3)
+		require.NoError(t, err)
+		assert.Equal(t, "http://b.tile.openstreetmap.org/3/1/2.png", url)
 
-	// check correct c... url is returned
-	url, err = TileProvider.GetTileAddress(1, 2, 3)
-	if err != nil {
-		t.Error(err)
-	}
-	if url != "http://c.tile.openstreetmap.org/3/1/2.png" {
-		t.Errorf("Expected http://c.tile.openstreetmap.org/3/1/2.png, got: %s", url)
-	}
+		// check correct c... url is returned
+		url, err = TileProvider.GetTileAddress(1, 2, 3)
+		require.NoError(t, err)
+		assert.Equal(t, "http://c.tile.openstreetmap.org/3/1/2.png", url)
 
-	// check correct a... url is returned (it loops back to a after c)
-	url, err = TileProvider.GetTileAddress(1, 2, 3)
-	if err != nil {
-		t.Error(err)
-	}
-	if url != "http://a.tile.openstreetmap.org/3/1/2.png" {
-		t.Errorf("Expected http://a.tile.openstreetmap.org/3/1/2.png, got: %s", url)
-	}
-
-	// set invalid tile prefix to generate an error
-	TileProvider.osm_url_prefix = 4
-	url, err = TileProvider.GetTileAddress(1, 2, 3)
-	if err != nil {
-		// test passes
-	} else {
-		t.Error("Expected an error, got none.")
-	}
+		// check correct a... url is returned (it loops back to a after c)
+		url, err = TileProvider.GetTileAddress(1, 2, 3)
+		require.NoError(t, err)
+		assert.Equal(t, "http://a.tile.openstreetmap.org/3/1/2.png", url)
+	})
 }


### PR DESCRIPTION
Closes #10 

I left this code in `OSMTileProvider ` knowing it would be a race condition, but a super low impact race condition I didn't care about. But since we've now got race detector turned on, let's make the race go away so the race detector can do its job betterer.

Race is caused by `GetTileAddress` being called by lots of goroutines at once, and all of them accessing and then setting `osm_url_prefix` and conflicting with each other